### PR TITLE
Fix Kakapo logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/bluedaniel/Kakapo-assets/master/icons/social/kakapo.png" width="128" height="128" align="right" />
+<img src="https://raw.githubusercontent.com/bluedaniel/Kakapo-assets/master/images/kakapo_border.png" width="128" height="128" align="right" />
 
 [Kakapo](http://kakapo.co) is an open source ambient sound mixer for relaxation or productivity, available on the [Chrome Web Store](https://chrome.google.com/webstore/detail/kakapo-for-chrome/hjbpmbeapabclfmopcoblnhcglplffmp).
 


### PR DESCRIPTION
Apparently, the Kakapo asset locations have changed since you last used them. I fixed the URL that the Markdown linked to so that it displayed the same images as the kakapo-app and kakapo-native repositories. I hope this fix helps.

Thanks,
The @ethertyper
